### PR TITLE
refactor/#78 Refactor template.html

### DIFF
--- a/src/main/resources/HTML/template.html
+++ b/src/main/resources/HTML/template.html
@@ -12,12 +12,13 @@
 
     .result {
         float: left;
-        margin: auto;
+       	margin-left: auto;
+        margin-right: auto;
     }
 
     .pillar {
         width: 20px;
-        background-color: red;
+        margin-top:auto;
     }
 
     .result_container {


### PR DESCRIPTION
Refactor the style in the template.html so that the graphic result bars are not centered on the vertical axis, and instead start at the bottom. fixes #78 